### PR TITLE
Add error logging to run_to_validate.sh and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,44 @@
+# Project Setup and Validation
+
+This project includes a setup and validation script located at `doc/run_to_validate.sh`.
+
+## `doc/run_to_validate.sh`
+
+This script is designed to prepare the context and virtual machine environment for the project. It performs various setup tasks, installs dependencies, and configures the necessary services.
+
+### Usage
+
+To execute the script, navigate to the `doc/` directory and run it using bash:
+
+```bash
+cd doc
+bash run_to_validate.sh
+```
+
+Or run it from the project root:
+
+```bash
+bash doc/run_to_validate.sh
+```
+
+## `doc/run_to_validate_errors.log`
+
+All output from the `run_to_validate.sh` script, including any errors encountered during its execution, is automatically logged to the `doc/run_to_validate_errors.log` file.
+
+### Checking for Errors
+
+After running the `run_to_validate.sh` script, you can check the `doc/run_to_validate_errors.log` file to review the execution details and identify any potential issues.
+
+For example, you can view the entire log:
+
+```bash
+cat doc/run_to_validate_errors.log
+```
+
+Or search for specific error messages:
+
+```bash
+grep -i "error" doc/run_to_validate_errors.log
+```
+
+This log file is crucial for troubleshooting and ensuring that the environment has been set up correctly.

--- a/doc/run_to_validate.sh
+++ b/doc/run_to_validate.sh
@@ -2,6 +2,10 @@
 # Setup Script Jules FINAL CORRIGÉ - Budget Workflow Laravel  
 # Version définitive sans IPv6 + Configuration exhaustive
 
+# Redirect all output to a log file in the same directory
+LOG_FILE_PATH="$(dirname "$0")/run_to_validate_errors.log"
+exec > >(tee -a "${LOG_FILE_PATH}") 2>&1
+
 set -e  # Arrêt sur erreur
 
 echo "🚀 SETUP BUDGET WORKFLOW - Configuration Jules Définitive"


### PR DESCRIPTION
- Modified doc/run_to_validate.sh to redirect all output (stdout and stderr) to doc/run_to_validate_errors.log while still printing stdout to the console.
- Created README.md to explain the purpose and usage of the script and log file.